### PR TITLE
Fix: KeyError

### DIFF
--- a/churn_library.py
+++ b/churn_library.py
@@ -88,7 +88,7 @@ def encoder_helper(dataframe, category_lst, response=""):
         category_groups = dataframe.groupby(category).mean()["Churn"]
         for val in dataframe[category]:
             category_col_lst.append(category_groups.loc[val])
-        dataframe[f"{category}_{response}_Churn"] = category_col_lst
+        dataframe[f"{category}_Churn"] = category_col_lst
     return dataframe
 
 def perform_feature_engineering(dataframe,response=""):


### PR DESCRIPTION
The encoder_helper function creates encoded features having Two "_" in their naming. 
![Cursor_and_Predict_Customer_Churn_with_Clean_Code](https://github.com/apapadogiannakis/udacity_clean_code/assets/18123459/0a82f9f0-d9f4-4b02-8038-9323110fcb4f)

That is why you were getting the keyerror